### PR TITLE
nit: README.md - add temp.log to original list of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ my_directory/file2.txt
 ---
 Contents of file2.txt
 ---
+my_directory/temp.log
+---
+Contents of temp.log
+---
 my_directory/subdirectory/file3.txt
 ---
 Contents of file3.txt


### PR DESCRIPTION
The first example should include `temp.log`. It's only explicitly excluded in the later example.