### PR TITLE
added --mtime for date filtering

### DIFF
--- a/files_to_prompt/cli.py
+++ b/files_to_prompt/cli.py
@@ -2,8 +2,10 @@ import os
 from fnmatch import fnmatch
 
 import click
+from datetime import datetime, timedelta
 
 global_index = 1
+current_time = datetime.now()  # Track current time for date comparison filters
 
 
 def should_ignore(path, gitignore_rules):
@@ -23,6 +25,51 @@ def read_gitignore(path):
                 line.strip() for line in f if line.strip() and not line.startswith("#")
             ]
     return []
+
+
+def parse_time_delta(delta_str):
+    """
+    Parse a string in the format "30s", "30m", "30h", "30d", etc. into a timedelta object.
+
+    Args:
+        delta_str (str): The string to parse.
+
+    Returns:
+        timedelta: The parsed timedelta object.
+
+    Raises:
+        ValueError: If the input string is invalid.
+    """
+    import re
+
+    match = re.match(r"(\d+)([smhd])", delta_str)
+    if match:
+        value = int(match.group(1))
+        unit = match.group(2)
+        if unit == "s":
+            return timedelta(seconds=value)
+        elif unit == "m":
+            return timedelta(minutes=value)
+        elif unit == "h":
+            return timedelta(hours=value)
+        elif unit == "d":
+            return timedelta(days=value)
+    raise ValueError("Invalid time delta string")
+
+
+def filter_by_mtime(path, mtime_delta):
+    """
+    Filter files based on their modification time.
+
+    Args:
+        path (str): The file path to check.
+        mtime_delta (timedelta): The time delta to filter by.
+
+    Returns:
+        bool: True if the file's modification time is within the delta, False otherwise.
+    """
+    file_mtime = datetime.fromtimestamp(os.path.getmtime(path))
+    return current_time - file_mtime <= mtime_delta
 
 
 def print_path(writer, path, content, xml):
@@ -57,10 +104,13 @@ def process_path(
     ignore_gitignore,
     gitignore_rules,
     ignore_patterns,
+    mtime_delta,
     writer,
     claude_xml,
 ):
     if os.path.isfile(path):
+        if mtime_delta is not None and not filter_by_mtime(path, mtime_delta):
+            return  # skip file if it's older than specified delta
         try:
             with open(path, "r") as f:
                 print_path(writer, path, f.read(), claude_xml)
@@ -91,6 +141,13 @@ def process_path(
                     f
                     for f in files
                     if not any(fnmatch(f, pattern) for pattern in ignore_patterns)
+                ]
+
+            if mtime_delta is not None:
+                files = [
+                    f
+                    for f in files
+                    if filter_by_mtime(os.path.join(root, f), mtime_delta)
                 ]
 
             for file in sorted(files):
@@ -125,6 +182,12 @@ def process_path(
     help="List of patterns to ignore",
 )
 @click.option(
+    "--mtime",
+    type=str,
+    default=None,
+    help="Filter files modified in the last 'delta' time. Examples: 30s, 30m, 30h, 30d",
+)
+@click.option(
     "output_file",
     "-o",
     "--output",
@@ -140,7 +203,13 @@ def process_path(
 )
 @click.version_option()
 def cli(
-    paths, include_hidden, ignore_gitignore, ignore_patterns, output_file, claude_xml
+    paths,
+    include_hidden,
+    ignore_gitignore,
+    ignore_patterns,
+    mtime,
+    output_file,
+    claude_xml,
 ):
     """
     Takes one or more paths to files or directories and outputs every file,
@@ -174,9 +243,18 @@ def cli(
     gitignore_rules = []
     writer = click.echo
     fp = None
+
     if output_file:
         fp = open(output_file, "w")
         writer = lambda s: print(s, file=fp)
+
+    mtime_delta = None
+    if mtime is not None:
+        try:
+            mtime_delta = parse_time_delta(mtime)
+        except ValueError as e:
+            raise click.BadOptionUsage("--mtime", str(e))
+
     for path in paths:
         if not os.path.exists(path):
             raise click.BadArgumentUsage(f"Path does not exist: {path}")
@@ -190,6 +268,7 @@ def cli(
             ignore_gitignore,
             gitignore_rules,
             ignore_patterns,
+            mtime_delta,
             writer,
             claude_xml,
         )

--- a/files_to_prompt/cli.py
+++ b/files_to_prompt/cli.py
@@ -1,49 +1,43 @@
 import os
 from fnmatch import fnmatch
-
-import click
 from datetime import datetime, timedelta
 
-global_index = 1
-current_time = datetime.now()  # to be able to track current time for date comparison filters
+import click
 
+class FileProcessor:
+    def __init__(self):
+        self.global_index = 1
+        self.current_time = datetime.now()
 
-def should_ignore(path, gitignore_rules):
-    for rule in gitignore_rules:
-        if fnmatch(os.path.basename(path), rule):
-            return True
-        if os.path.isdir(path) and fnmatch(os.path.basename(path) + "/", rule):
-            return True
-    return False
+    def should_ignore(self, path, gitignore_rules):
+        basename = os.path.basename(path)
+        for rule in gitignore_rules:
+            if fnmatch(basename, rule):
+                return True
+            if os.path.isdir(path) and fnmatch(basename + "/", rule):
+                return True
+        return False
 
+    def read_gitignore(self, path):
+        gitignore_path = os.path.join(path, ".gitignore")
+        if os.path.isfile(gitignore_path):
+            with open(gitignore_path, "r") as f:
+                return [
+                    line.strip()
+                    for line in f
+                    if line.strip() and not line.startswith("#")
+                ]
+        return []
 
-def read_gitignore(path):
-    gitignore_path = os.path.join(path, ".gitignore")
-    if os.path.isfile(gitignore_path):
-        with open(gitignore_path, "r") as f:
-            return [
-                line.strip() for line in f if line.strip() and not line.startswith("#")
-            ]
-    return []
+    def parse_time_delta(self, delta_str):
+        """Parse a string like "30s", "1h", "7d" into a timedelta object."""
+        import re
 
-
-def parse_time_delta(delta_str):
-    """
-    Parse a string in the format "30s", "30m", "30h", "30d", etc. into a timedelta object.
-
-    Args:
-        delta_str (str): The string to parse.
-
-    Returns:
-        timedelta: The parsed timedelta object.
-
-    Raises:
-        ValueError: If the input string is invalid.
-    """
-    import re
-
-    match = re.match(r"(\d+)([smhd])", delta_str)
-    if match:
+        match = re.match(r"(\d+)([smhd])", delta_str)
+        if not match:
+            raise ValueError(
+                "Invalid time delta string. Use format like 30s, 1m, 2h, 7d"
+            )
         value = int(match.group(1))
         unit = match.group(2)
         if unit == "s":
@@ -54,252 +48,223 @@ def parse_time_delta(delta_str):
             return timedelta(hours=value)
         elif unit == "d":
             return timedelta(days=value)
-    raise ValueError("Invalid time delta string")
+        return None  # Should not happen due to regex, but for completeness
 
+    def is_modified_within_delta(self, path, mtime_delta):
+        """Check if a file was modified within the specified timedelta."""
+        file_mtime = datetime.fromtimestamp(os.path.getmtime(path))
+        return self.current_time - file_mtime <= mtime_delta
 
-def parse_time_delta(delta_str):
-    """
-    Parse a string in the format "30s", "30m", "30h", "30d", etc. into a timedelta object.
+    def format_output(self, path, content, llm_format=None):
+        if llm_format == "claude":
+            return self._format_as_xml(path, content)
+        elif llm_format == "openai":
+            return self._format_markdown(path, content)
+        elif llm_format == "gemini":
+            return self._format_gemini(path, content)
+        else:
+            return self._format_default(path, content)
 
-    Args:
-        delta_str (str): The string to parse.
+    def _format_default(self, path, content):
+        return f"{path}\n---\n{content}\n\n---\n"
 
-    Returns:
-        timedelta: The parsed timedelta object.
+    def _format_as_xml(self, path, content):
+        output = (
+            f'<document index="{self.global_index}">\n'
+            f"<source>{path}</source>\n"
+            "<document_content>\n"
+            f"{content}\n"
+            "</document_content>\n"
+            "</document>\n"
+        )
+        self.global_index += 1
+        return output
 
-    Raises:
-        ValueError: If the input string is invalid.
-    """
-    import re
+    def _format_markdown(self, path, content):
+        return f"## {path}\n```\n{content}\n```\n\n"
 
-    match = re.match(r"(\d+)([smhd])", delta_str)
-    if match:
-        value = int(match.group(1))
-        unit = match.group(2)
-        if unit == "s":
-            return timedelta(seconds=value)
-        elif unit == "m":
-            return timedelta(minutes=value)
-        elif unit == "h":
-            return timedelta(hours=value)
-        elif unit == "d":
-            return timedelta(days=value)
-    raise ValueError("Invalid time delta string")
+    def _format_gemini(self, path, content):
+        return f"## File: {path}\n```\n{content}\n```\n\n"
 
-
-def filter_by_mtime(path, mtime_delta):
-    """
-    Filter files based on their modification time.
-
-    Args:
-        path (str): The file path to check.
-        mtime_delta (timedelta): The time delta to filter by.
-
-    Returns:
-        bool: True if the file's modification time is within the delta, False otherwise.
-    """
-    file_mtime = datetime.fromtimestamp(os.path.getmtime(path))
-    return current_time - file_mtime <= mtime_delta
-
-
-def print_path(writer, path, content, xml):
-    if xml:
-        print_as_xml(writer, path, content)
-    else:
-        print_default(writer, path, content)
-
-
-def print_default(writer, path, content):
-    writer(path)
-    writer("---")
-    writer(content)
-    writer("")
-    writer("---")
-
-
-def print_as_xml(writer, path, content):
-    global global_index  # Move global declaration before any assignment
-    writer(f'<document index="{global_index}">')
-    writer(f"<source>{path}</source>")
-    writer("<document_content>")
-    writer(content)
-    writer("</document_content>")
-    writer("</document>")
-    global_index += 1  # This is now valid after the global declaration
-
-def process_path(
-    path,
-    include_hidden,
-    ignore_gitignore,
-    gitignore_rules,
-    ignore_patterns,
-    include_patterns,  # Added this
-    mtime_delta,
-    writer,
-    claude_xml,
-):
-    if os.path.isfile(path):
-        if include_patterns and not any(fnmatch(os.path.basename(path), pattern) for pattern in include_patterns):
-            return  # Skip file if it does not match include patterns
-        if mtime_delta is not None and not filter_by_mtime(path, mtime_delta):
-            return  # Skip file if it's older than specified delta
+    def process_file(self, file_path, writer, llm_format):
         try:
-            with open(path, "r") as f:
-                print_path(writer, path, f.read(), claude_xml)
+            with open(file_path, "r") as f:
+                content = f.read()
+                writer(self.format_output(file_path, content, llm_format))
         except UnicodeDecodeError:
-            warning_message = f"Warning: Skipping file {path} due to UnicodeDecodeError"
+            warning_message = (
+                f"Warning: Skipping file {file_path} due to UnicodeDecodeError"
+            )
             click.echo(click.style(warning_message, fg="red"), err=True)
-    elif os.path.isdir(path):
+
+    def process_directory(
+        self,
+        path,
+        extensions,
+        include_hidden,
+        ignore_gitignore,
+        gitignore_rules,
+        ignore_patterns,
+        include_patterns,
+        mtime_delta,
+        writer,
+        llm_format,
+    ):
         for root, dirs, files in os.walk(path):
-            if not include_hidden:
-                dirs[:] = [d for d in dirs if not d.startswith(".")]
-                files = [f for f in files if not f.startswith(".")]
+            # Filter directories
+            dirs[:] = [
+                d
+                for d in dirs
+                if (include_hidden or not d.startswith("."))
+                and (ignore_gitignore or not self.should_ignore(os.path.join(root, d), gitignore_rules))
+            ]
 
+            # Filter files
+            files = sorted([
+                f
+                for f in files
+                if (include_hidden or not f.startswith("."))
+                and (ignore_gitignore or not self.should_ignore(os.path.join(root, f), gitignore_rules))
+                and (not extensions or f.endswith(extensions))
+                and (not ignore_patterns or not any(fnmatch(f, pattern) for pattern in ignore_patterns))
+                and (not include_patterns or any(fnmatch(f, pattern) for pattern in include_patterns))
+                and (mtime_delta is None or self.is_modified_within_delta(os.path.join(root, f), mtime_delta))
+            ])
+
+            for file in files:
+                self.process_file(os.path.join(root, file), writer, llm_format)
+
+    def process_path(
+        self,
+        path,
+        extensions,
+        include_hidden,
+        ignore_gitignore,
+        ignore_patterns,
+        include_patterns,
+        mtime_delta,
+        writer,
+        llm_format,
+    ):
+        if os.path.isfile(path):
+            if (not include_patterns or any(fnmatch(os.path.basename(path), pattern) for pattern in include_patterns)) and \
+               (mtime_delta is None or self.is_modified_within_delta(path, mtime_delta)):
+                self.process_file(path, writer, llm_format)
+        elif os.path.isdir(path):
             if not ignore_gitignore:
-                gitignore_rules.extend(read_gitignore(root))
-                dirs[:] = [
-                    d
-                    for d in dirs
-                    if not should_ignore(os.path.join(root, d), gitignore_rules)
-                ]
-                files = [
-                    f
-                    for f in files
-                    if not should_ignore(os.path.join(root, f), gitignore_rules)
-                ]
+                gitignore_rules = self.read_gitignore(path)
+            else:
+                gitignore_rules = []
+            self.process_directory(
+                path,
+                extensions,
+                include_hidden,
+                ignore_gitignore,
+                gitignore_rules,
+                ignore_patterns,
+                include_patterns,
+                mtime_delta,
+                writer,
+                llm_format,
+            )
 
-            if ignore_patterns:
-                files = [
-                    f
-                    for f in files
-                    if not any(fnmatch(f, pattern) for pattern in ignore_patterns)
-                ]
-            
-            # Include pattern filter
-            if include_patterns:
-                files = [
-                    f
-                    for f in files
-                    if any(fnmatch(f, pattern) for pattern in include_patterns)
-                ]
-
-            if mtime_delta is not None:
-                files = [
-                    f
-                    for f in files
-                    if filter_by_mtime(os.path.join(root, f), mtime_delta)
-                ]
-
-            for file in sorted(files):
-                file_path = os.path.join(root, file)
-                try:
-                    with open(file_path, "r") as f:
-                        print_path(writer, file_path, f.read(), claude_xml)
-                except UnicodeDecodeError:
-                    warning_message = (
-                        f"Warning: Skipping file {file_path} due to UnicodeDecodeError"
-                    )
-                    click.echo(click.style(warning_message, fg="red"), err=True)
-
+def print_output(s, file=None):
+    print(s, file=file)
 
 @click.command()
 @click.argument("paths", nargs=-1, type=click.Path(exists=True))
+@click.option("-e", "--extension", multiple=True, help="Filter by file extension.")
 @click.option(
-    "--include-hidden",
-    is_flag=True,
-    help="Include files and folders starting with .",
+    "--include-hidden", is_flag=True, help="Include hidden files and directories."
 )
 @click.option(
-    "--ignore-gitignore",
-    is_flag=True,
-    help="Ignore .gitignore files and include all files",
+    "--ignore-gitignore", is_flag=True, help="Ignore .gitignore rules."
 )
-@click.option(
-    "ignore_patterns",
-    "--ignore",
-    multiple=True,
-    default=[],
-    help="List of patterns to ignore",
-)
-@click.option(
-    "include_patterns",
-    "--include",
-    multiple=True,
-    default=[],
-    help="List of patterns to include"
-)
+@click.option("--ignore", multiple=True, help="Ignore files matching this pattern.")
+@click.option("--include", multiple=True, help="Include files matching this pattern.")
 @click.option(
     "--mtime",
     type=str,
-    default=None,
-    help="Filter files modified in the last 'delta' time. Examples: 30s, 30m, 30h, 30d",
+    help="Filter files modified within the given time (e.g., 30s, 1h, 7d).",
 )
+@click.option("-o", "--output", type=click.Path(writable=True), help="Output to file.")
 @click.option(
-    "output_file",
-    "-o",
-    "--output",
-    type=click.Path(writable=True),
-    help="Output to a file instead of stdout",
-)
-@click.option(
-    "claude_xml",
-    "-c",
-    "--cxml",
-    is_flag=True,
-    help="Output in XML-ish format suitable for Claude's long context window.",
+    "--llm-format",
+    type=click.Choice(["claude", "openai", "gemini"]),
+    help="Format output for a specific LLM.",
 )
 @click.version_option()
 def cli(
     paths,
+    extension,
     include_hidden,
     ignore_gitignore,
-    ignore_patterns,
-    include_patterns,
+    ignore,
+    include,
     mtime,
-    output_file,
-    claude_xml,
+    output,
+    llm_format,
 ):
     """
-    Takes one or more paths to files or directories and outputs every file,
-    recursively, each one preceded with its filename.
-    """
-    global global_index  # Declare the global variable before assigning or using it
-    global_index = 1  # Reset the global index to 1 for each run
+    Concatenates the content of files into a single output, optimized for LLMs.
 
-    gitignore_rules = []
+    Specify one or more paths to files or directories.
+    Recursively outputs the content of each file,
+    optionally formatted for specific LLMs.
+
+    Example (default output):
+
+    \b
+    path/to/file.py
+    ---
+    Contents of file.py goes here
+
+    ---
+    path/to/file2.py
+    ---
+    ...
+
+    Use --llm-format to structure the output for specific LLMs.
+    """
+    processor = FileProcessor()
     writer = click.echo
     fp = None
 
-    if output_file:
-        fp = open(output_file, "w")
-        writer = lambda s: print(s, file=fp)
+    if output:
+        fp = open(output, "w")
+        def writer(s):
+            print_output(s, file=fp)
 
     mtime_delta = None
-    if mtime is not None:
+    if mtime:
         try:
-            mtime_delta = parse_time_delta(mtime)
+            mtime_delta = processor.parse_time_delta(mtime)
         except ValueError as e:
             raise click.BadOptionUsage("--mtime", str(e))
+
+    if llm_format == "claude":
+        writer("<documents>")
 
     for path in paths:
         if not os.path.exists(path):
             raise click.BadArgumentUsage(f"Path does not exist: {path}")
-        if not ignore_gitignore:
-            gitignore_rules.extend(read_gitignore(os.path.dirname(path)))
-        if claude_xml and path == paths[0]:
-            writer("<documents>")
-        process_path(
+        processor.process_path(
             path,
+            extension,
             include_hidden,
             ignore_gitignore,
-            gitignore_rules,
-            ignore_patterns,
-            include_patterns,
+            ignore,
+            include,
             mtime_delta,
             writer,
-            claude_xml,
+            llm_format,
         )
-    if claude_xml:
+
+    if llm_format == "claude":
         writer("</documents>")
+
     if fp:
         fp.close()
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
I had something like this on my fork from a little while ago, thought I'd share here in case anyone finds it helpful. 

I often need to only share deltas based on modifications, and the --mtime flag will essentially allow you to do things like this:

```
# Show files modified in the last 30 seconds
files-to-prompt  --mtime 30s path/to/files

# Show files modified in the last 1 minute
files-to-prompt --mtime 1m path/to/files

# Show files modified in the last 2 hours
files-to-prompt --mtime 2h path/to/files

# Show files modified in the last 3 days
files-to-prompt --mtime 3d path/to/files

# Show files modified in the last 1 week (7 days)
files-to-prompt --mtime 7d path/to/files
```