### PR TITLE
github to prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,19 @@ Contents of file3.txt
 ---
 ```
 
+### GitHub Repository Support
+
+You can now use `files-to-prompt` to process files directly from a GitHub repository:
+
+```bash
+files-to-prompt --github-repo https://github.com/username/repo.git --github-path path/in/repo
+```
+
+Pass a github token using the `--github-token` option:
+```bash
+files-to-prompt --github-repo https://github.com/username/repo.git --github-path path/in/repo --github-token your_github_token
+``` 
+
 ### Claude XML Output
 
 Anthropic has provided [specific guidelines](https://docs.anthropic.com/claude/docs/long-context-window-tips) for optimally structuring prompts to take advantage of Claude's extended context window.

--- a/files_to_prompt/cli.py
+++ b/files_to_prompt/cli.py
@@ -1,5 +1,7 @@
 import os
 from fnmatch import fnmatch
+import requests
+import base64
 
 import click
 
@@ -105,8 +107,56 @@ def process_path(
                     click.echo(click.style(warning_message, fg="red"), err=True)
 
 
+def fetch_github_files(repo_url, path="", token=None):
+    # Extract owner and repo from the URL
+    parts = repo_url.rstrip('/').split('/')
+    if len(parts) < 2:
+        raise click.ClickException(f"Invalid GitHub repository URL: {repo_url}")
+    owner, repo = parts[-2], parts[-1]
+    if repo.endswith('.git'):
+        repo = repo[:-4]
+
+    api_url = f"https://api.github.com/repos/{owner}/{repo}/contents/{path}"
+    headers = {}
+    if token:
+        headers["Authorization"] = f"token {token}"
+    
+    try:
+        response = requests.get(api_url, headers=headers)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        raise click.ClickException(f"Error fetching GitHub repository: {str(e)}")
+
+    content = response.json()
+    files = []
+
+    if isinstance(content, list):
+        for item in content:
+            if item["type"] == "file":
+                file_url = item["download_url"]
+                try:
+                    file_content = requests.get(file_url, headers=headers).text
+                    files.append((item["path"], file_content))
+                except requests.exceptions.RequestException as e:
+                    click.echo(f"Warning: Failed to fetch file {item['path']}: {str(e)}", err=True)
+            elif item["type"] == "dir":
+                files.extend(fetch_github_files(repo_url, item["path"], token))
+    elif isinstance(content, dict) and content["type"] == "file":
+        file_url = content["download_url"]
+        try:
+            file_content = requests.get(file_url, headers=headers).text
+            files.append((content["path"], file_content))
+        except requests.exceptions.RequestException as e:
+            click.echo(f"Warning: Failed to fetch file {content['path']}: {str(e)}", err=True)
+    
+    return files
+
+
 @click.command()
-@click.argument("paths", nargs=-1, type=click.Path(exists=True))
+@click.argument("paths", nargs=-1, type=click.Path(exists=True), required=False)
+@click.option("--github-repo", help="GitHub repository URL (e.g., https://github.com/username/repo.git)")
+@click.option("--github-path", default="", help="Path within the GitHub repository (default: entire repo)")
+@click.option("--github-token", envvar="GITHUB_TOKEN", help="GitHub personal access token")
 @click.option(
     "--include-hidden",
     is_flag=True,
@@ -140,7 +190,7 @@ def process_path(
 )
 @click.version_option()
 def cli(
-    paths, include_hidden, ignore_gitignore, ignore_patterns, output_file, claude_xml
+    paths, github_repo, github_path, github_token, include_hidden, ignore_gitignore, ignore_patterns, output_file, claude_xml
 ):
     """
     Takes one or more paths to files or directories and outputs every file,
@@ -177,22 +227,42 @@ def cli(
     if output_file:
         fp = open(output_file, "w")
         writer = lambda s: print(s, file=fp)
-    for path in paths:
-        if not os.path.exists(path):
-            raise click.BadArgumentUsage(f"Path does not exist: {path}")
-        if not ignore_gitignore:
-            gitignore_rules.extend(read_gitignore(os.path.dirname(path)))
-        if claude_xml and path == paths[0]:
-            writer("<documents>")
-        process_path(
-            path,
-            include_hidden,
-            ignore_gitignore,
-            gitignore_rules,
-            ignore_patterns,
-            writer,
-            claude_xml,
-        )
+    
+    if claude_xml:
+        writer("<documents>")
+
+    if github_repo:
+        try:
+            github_files = fetch_github_files(github_repo, github_path, github_token)
+            if not github_files:
+                raise click.ClickException(f"No files found in the specified GitHub repository: {github_repo}")
+            for file_path, content in github_files:
+                if claude_xml:
+                    print_as_xml(writer, file_path, content)
+                else:
+                    print_default(writer, file_path, content)
+        except click.ClickException as e:
+            click.echo(str(e), err=True)
+            return
+    elif paths:
+        for path in paths:
+            if not os.path.exists(path):
+                raise click.BadArgumentUsage(f"Path does not exist: {path}")
+            if not ignore_gitignore:
+                gitignore_rules.extend(read_gitignore(os.path.dirname(path)))
+            process_path(
+                path,
+                include_hidden,
+                ignore_gitignore,
+                gitignore_rules,
+                ignore_patterns,
+                writer,
+                claude_xml,
+            )
+    else:
+        click.echo("Please provide either local paths or a GitHub repository URL.", err=True)
+        return
+
     if claude_xml:
         writer("</documents>")
     if fp:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "files-to-prompt"
-version = "0.3"
+version = "0.4"
 description = "Concatenate a directory full of files into a single prompt for use with LLMs"
 readme = "README.md"
 authors = [{name = "Simon Willison"}]
@@ -10,7 +10,8 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "click"
+    "click",
+    "requests"
 ]
 
 [project.urls]

--- a/tests/test_files_to_prompt.py
+++ b/tests/test_files_to_prompt.py
@@ -287,7 +287,15 @@ def test_github_repo_fetch_with_token(tmpdir):
     assert result.exit_code == 0
     assert "file1.txt" in result.output
     assert "File content" in result.output
-    mock_get.assert_called_with(
+    
+    # Check that the initial API call was made correctly
+    mock_get.assert_any_call(
         "https://api.github.com/repos/simonw/llm/contents/",
+        headers={"Authorization": "token test_token"}
+    )
+    
+    # Check that the file content was fetched
+    mock_get.assert_any_call(
+        "http://example.com/file1.txt",
         headers={"Authorization": "token test_token"}
     )


### PR DESCRIPTION
This PR adds support for fetching files directly from GitHub repositories.

New features:
- Ability to fetch files from a GitHub repo using `--github-repo` option
- Support for specifying a path within the repo using `--github-path`
- GitHub token support for authentication (via `--github-token` or `GITHUB_TOKEN` env var)

New dependencies:
- Added `requests` library

Usage example:
```bash
files-to-prompt --github-repo https://github.com/username/repo.git
```