### PR TITLE
added --ignore-files-with-no-extension with text case

### DIFF
--- a/files_to_prompt/cli.py
+++ b/files_to_prompt/cli.py
@@ -57,6 +57,7 @@ def process_path(
     ignore_gitignore,
     gitignore_rules,
     ignore_patterns,
+    ignore_files_with_no_extension,
     writer,
     claude_xml,
 ):
@@ -92,6 +93,9 @@ def process_path(
                     for f in files
                     if not any(fnmatch(f, pattern) for pattern in ignore_patterns)
                 ]
+
+            if ignore_files_with_no_extension:
+                files = [f for f in files if os.path.splitext(f)[1]]
 
             for file in sorted(files):
                 file_path = os.path.join(root, file)
@@ -138,9 +142,15 @@ def process_path(
     is_flag=True,
     help="Output in XML-ish format suitable for Claude's long context window.",
 )
+@click.option(
+    "--ignore-files-with-no-extension",
+    is_flag=True,
+    help="Ignore files that don't have an extension",
+)
 @click.version_option()
 def cli(
-    paths, include_hidden, ignore_gitignore, ignore_patterns, output_file, claude_xml
+    paths, include_hidden, ignore_gitignore, ignore_patterns, output_file, claude_xml,
+    ignore_files_with_no_extension
 ):
     """
     Takes one or more paths to files or directories and outputs every file,
@@ -190,6 +200,7 @@ def cli(
             ignore_gitignore,
             gitignore_rules,
             ignore_patterns,
+            ignore_files_with_no_extension,
             writer,
             claude_xml,
         )

--- a/tests/test_files_to_prompt.py
+++ b/tests/test_files_to_prompt.py
@@ -190,7 +190,46 @@ def test_binary_file_warning(tmpdir):
             in stderr
         )
 
+        
+def test_ignore_files_with_no_extension(tmpdir):
+    runner = CliRunner()
+    with tmpdir.as_cwd():
+        os.makedirs("test_dir")
+        with open("test_dir/file_with_extension.txt", "w") as f:
+            f.write("This file has an extension")
+        with open("test_dir/file_without_extension", "w") as f:
+            f.write("This file has no extension")
+        with open("test_dir/.hidden_file_without_extension", "w") as f:
+            f.write("This is a hidden file without extension")
 
+        # Test without the option
+        result = runner.invoke(cli, ["test_dir"])
+        assert result.exit_code == 0
+        assert "test_dir/file_with_extension.txt" in result.output
+        assert "This file has an extension" in result.output
+        assert "test_dir/file_without_extension" in result.output
+        assert "This file has no extension" in result.output
+        assert "test_dir/.hidden_file_without_extension" not in result.output
+
+        # Test with the option
+        result = runner.invoke(cli, ["test_dir", "--ignore-files-with-no-extension"])
+        assert result.exit_code == 0
+        assert "test_dir/file_with_extension.txt" in result.output
+        assert "This file has an extension" in result.output
+        assert "test_dir/file_without_extension" not in result.output
+        assert "This file has no extension" not in result.output
+        assert "test_dir/.hidden_file_without_extension" not in result.output
+
+        # Test with both --ignore-files-with-no-extension and --include-hidden
+        result = runner.invoke(cli, ["test_dir", "--ignore-files-with-no-extension", "--include-hidden"])
+        assert result.exit_code == 0
+        assert "test_dir/file_with_extension.txt" in result.output
+        assert "This file has an extension" in result.output
+        assert "test_dir/file_without_extension" not in result.output
+        assert "This file has no extension" not in result.output
+        assert "test_dir/.hidden_file_without_extension" not in result.output
+
+        
 @pytest.mark.parametrize(
     "args", (["test_dir"], ["test_dir/file1.txt", "test_dir/file2.txt"])
 )
@@ -222,6 +261,45 @@ Contents of file2.txt
 </documents>
 """
         assert expected.strip() == actual.strip()
+
+
+def test_ignore_files_with_no_extension(tmpdir):
+    runner = CliRunner()
+    with tmpdir.as_cwd():
+        os.makedirs("test_dir")
+        with open("test_dir/file_with_extension.txt", "w") as f:
+            f.write("This file has an extension")
+        with open("test_dir/file_without_extension", "w") as f:
+            f.write("This file has no extension")
+        with open("test_dir/.hidden_file_without_extension", "w") as f:
+            f.write("This is a hidden file without extension")
+
+        # Test without the option
+        result = runner.invoke(cli, ["test_dir"])
+        assert result.exit_code == 0
+        assert "test_dir/file_with_extension.txt" in result.output
+        assert "This file has an extension" in result.output
+        assert "test_dir/file_without_extension" in result.output
+        assert "This file has no extension" in result.output
+        assert "test_dir/.hidden_file_without_extension" not in result.output
+
+        # Test with the option
+        result = runner.invoke(cli, ["test_dir", "--ignore-files-with-no-extension"])
+        assert result.exit_code == 0
+        assert "test_dir/file_with_extension.txt" in result.output
+        assert "This file has an extension" in result.output
+        assert "test_dir/file_without_extension" not in result.output
+        assert "This file has no extension" not in result.output
+        assert "test_dir/.hidden_file_without_extension" not in result.output
+
+        # Test with both --ignore-files-with-no-extension and --include-hidden
+        result = runner.invoke(cli, ["test_dir", "--ignore-files-with-no-extension", "--include-hidden"])
+        assert result.exit_code == 0
+        assert "test_dir/file_with_extension.txt" in result.output
+        assert "This file has an extension" in result.output
+        assert "test_dir/file_without_extension" not in result.output
+        assert "This file has no extension" not in result.output
+        assert "test_dir/.hidden_file_without_extension" not in result.output
 
 
 @pytest.mark.parametrize("arg", ("-o", "--output"))


### PR DESCRIPTION
This allows you to pass an option called --ignore-files-with-no-extension, which ignores any files without an extension (e.g. no ".") which I find helpful as then I'm not collecting any non source code files typically. Also includes test case.