### PR TITLE
--ignore patterns now include directory names unless --ignore-files-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ This will output the contents of every file, with each file preceded by its rela
   files-to-prompt path/to/directory --include-hidden
   ```
 
-- `--include-directories`: Include directory paths which would otherwise be ignored by an `--ignore` pattern.
+- `--ignore-files-only`: Include directory paths which would otherwise be ignored by an `--ignore` pattern.
 
   ```bash
-  files-to-prompt path/to/directory --include-directories --ignore "*dir*"
+  files-to-prompt path/to/directory --ignore-files-only --ignore "*dir*"
   ```
 
 - `--ignore-gitignore`: Ignore `.gitignore` files and include all files.
@@ -53,7 +53,7 @@ This will output the contents of every file, with each file preceded by its rela
   files-to-prompt path/to/directory --ignore-gitignore
   ```
 
-- `--ignore <pattern>`: Specify one or more patterns to ignore. Can be used multiple times. Patterns may match file names and directory names, unless you also specify `--include-directories`.
+- `--ignore <pattern>`: Specify one or more patterns to ignore. Can be used multiple times. Patterns may match file names and directory names, unless you also specify `--ignore-files-only`.
   ```bash
   files-to-prompt path/to/directory --ignore "*.log" --ignore "temp*"
   ```
@@ -144,7 +144,7 @@ Contents of file3.txt
 ---
 ```
 
-If you run `files-to-prompt my_directory --ignore "sub*"`, the output will exclude all files in `subdirectory/` (unless you also specify `--include-directories`):
+If you run `files-to-prompt my_directory --ignore "sub*"`, the output will exclude all files in `subdirectory/` (unless you also specify `--ignore-files-only`):
 
 ```
 my_directory/file1.txt

--- a/README.md
+++ b/README.md
@@ -35,13 +35,19 @@ This will output the contents of every file, with each file preceded by its rela
   files-to-prompt path/to/directory --include-hidden
   ```
 
+- `--include-directories`: Include directory paths which would otherwise be ignored by an `--ignore` pattern.
+
+  ```bash
+  files-to-prompt path/to/directory --include-directories --ignore "*dir*"
+  ```
+
 - `--ignore-gitignore`: Ignore `.gitignore` files and include all files.
 
   ```bash
   files-to-prompt path/to/directory --ignore-gitignore
   ```
 
-- `--ignore <pattern>`: Specify one or more patterns to ignore. Can be used multiple times.
+- `--ignore <pattern>`: Specify one or more patterns to ignore. Can be used multiple times. Patterns may match file names and directory names, unless you also specify `--include-directories`.
   ```bash
   files-to-prompt path/to/directory --ignore "*.log" --ignore "temp*"
   ```
@@ -113,6 +119,19 @@ Contents of file2.txt
 my_directory/subdirectory/file3.txt
 ---
 Contents of file3.txt
+---
+```
+
+If you run `files-to-prompt my_directory --ignore "sub*"`, the output will exclude all files in `subdirectory/` (unless you also specify `--include-directories`):
+
+```
+my_directory/file1.txt
+---
+Contents of file1.txt
+---
+my_directory/file2.txt
+---
+Contents of file2.txt
 ---
 ```
 

--- a/files_to_prompt/cli.py
+++ b/files_to_prompt/cli.py
@@ -68,7 +68,7 @@ def process_path(
     path,
     extensions,
     include_hidden,
-    include_directories,
+    ignore_files_only,
     ignore_gitignore,
     gitignore_rules,
     ignore_patterns,
@@ -103,7 +103,7 @@ def process_path(
                 ]
 
             if ignore_patterns:
-                if not include_directories:
+                if not ignore_files_only:
                     dirs[:] = [
                         d
                         for d in dirs
@@ -141,9 +141,9 @@ def process_path(
     help="Include files and folders starting with .",
 )
 @click.option(
-    "--include-directories",
+    "--ignore-files-only",
     is_flag=True,
-    help="Include directories whose names match the patterns",
+    help="--ignore option only ignores files",
 )
 @click.option(
     "--ignore-gitignore",
@@ -183,7 +183,7 @@ def cli(
     paths,
     extensions,
     include_hidden,
-    include_directories,
+    ignore_files_only,
     ignore_gitignore,
     ignore_patterns,
     output_file,
@@ -236,7 +236,7 @@ def cli(
             path,
             extensions,
             include_hidden,
-            include_directories,
+            ignore_files_only,
             ignore_gitignore,
             gitignore_rules,
             ignore_patterns,

--- a/files_to_prompt/cli.py
+++ b/files_to_prompt/cli.py
@@ -54,6 +54,7 @@ def print_as_xml(writer, path, content):
 def process_path(
     path,
     include_hidden,
+    include_directories,
     ignore_gitignore,
     gitignore_rules,
     ignore_patterns,
@@ -87,11 +88,12 @@ def process_path(
                 ]
 
             if ignore_patterns:
-                dirs[:] = [
-                    d
-                    for d in dirs
-                    if not any(fnmatch(d, pattern) for pattern in ignore_patterns)
-                ]
+                if not include_directories:
+                    dirs[:] = [
+                        d
+                        for d in dirs
+                        if not any(fnmatch(d, pattern) for pattern in ignore_patterns)
+                    ]
                 files = [
                     f
                     for f in files
@@ -116,6 +118,11 @@ def process_path(
     "--include-hidden",
     is_flag=True,
     help="Include files and folders starting with .",
+)
+@click.option(
+    "--include-directories",
+    is_flag=True,
+    help="Include directories whose names match the patterns",
 )
 @click.option(
     "--ignore-gitignore",
@@ -145,7 +152,7 @@ def process_path(
 )
 @click.version_option()
 def cli(
-    paths, include_hidden, ignore_gitignore, ignore_patterns, output_file, claude_xml
+    paths, include_hidden, include_directories, ignore_gitignore, ignore_patterns, output_file, claude_xml
 ):
     """
     Takes one or more paths to files or directories and outputs every file,
@@ -192,6 +199,7 @@ def cli(
         process_path(
             path,
             include_hidden,
+            include_directories,
             ignore_gitignore,
             gitignore_rules,
             ignore_patterns,

--- a/files_to_prompt/cli.py
+++ b/files_to_prompt/cli.py
@@ -87,6 +87,11 @@ def process_path(
                 ]
 
             if ignore_patterns:
+                dirs[:] = [
+                    d
+                    for d in dirs
+                    if not any(fnmatch(d, pattern) for pattern in ignore_patterns)
+                ]
                 files = [
                     f
                     for f in files

--- a/tests/test_files_to_prompt.py
+++ b/tests/test_files_to_prompt.py
@@ -106,16 +106,20 @@ def test_ignore_patterns(tmpdir):
         result = runner.invoke(cli, ["test_dir", "--ignore", "*subdir*"])
         assert result.exit_code == 0
         assert "test_dir/test_subdir/any_file.txt" not in result.output
-        assert "This entire subdirectory should be ignored due to ignore patterns" not in result.output
+        assert (
+            "This entire subdirectory should be ignored due to ignore patterns"
+            not in result.output
+        )
         assert "test_dir/file_to_include.txt" in result.output
         assert "This file should be included" in result.output
         assert "This file should be included" in result.output
-        
-        
-        result = runner.invoke(cli, ["test_dir", "--ignore", "*subdir*", "--include-directories"])
+
+        result = runner.invoke(
+            cli, ["test_dir", "--ignore", "*subdir*", "--ignore-files-only"]
+        )
         assert result.exit_code == 0
         assert "test_dir/test_subdir/any_file.txt" in result.output
-        
+
         result = runner.invoke(cli, ["test_dir", "--ignore", ""])
 
 

--- a/tests/test_files_to_prompt.py
+++ b/tests/test_files_to_prompt.py
@@ -88,7 +88,7 @@ def test_multiple_paths(tmpdir):
 def test_ignore_patterns(tmpdir):
     runner = CliRunner()
     with tmpdir.as_cwd():
-        os.makedirs("test_dir")
+        os.makedirs("test_dir", exist_ok=True)
         with open("test_dir/file_to_ignore.txt", "w") as f:
             f.write("This file should be ignored due to ignore patterns")
         with open("test_dir/file_to_include.txt", "w") as f:
@@ -100,12 +100,18 @@ def test_ignore_patterns(tmpdir):
         assert "This file should be ignored due to ignore patterns" not in result.output
         assert "test_dir/file_to_include.txt" not in result.output
 
-        result = runner.invoke(cli, ["test_dir", "--ignore", "file_to_ignore.*"])
+        os.makedirs("test_dir/test_subdir", exist_ok=True)
+        with open("test_dir/test_subdir/any_file.txt", "w") as f:
+            f.write("This entire subdirectory should be ignored due to ignore patterns")
+        result = runner.invoke(cli, ["test_dir", "--ignore", "*subdir*"])
         assert result.exit_code == 0
-        assert "test_dir/file_to_ignore.txt" not in result.output
-        assert "This file should be ignored due to ignore patterns" not in result.output
+        assert "test_dir/test_subdir/any_file.txt" not in result.output
+        assert "This entire subdirectory should be ignored due to ignore patterns" not in result.output
         assert "test_dir/file_to_include.txt" in result.output
         assert "This file should be included" in result.output
+        assert "This file should be included" in result.output
+        
+        result = runner.invoke(cli, ["test_dir", "--ignore", ""])
 
 
 def test_mixed_paths_with_options(tmpdir):

--- a/tests/test_files_to_prompt.py
+++ b/tests/test_files_to_prompt.py
@@ -111,6 +111,11 @@ def test_ignore_patterns(tmpdir):
         assert "This file should be included" in result.output
         assert "This file should be included" in result.output
         
+        
+        result = runner.invoke(cli, ["test_dir", "--ignore", "*subdir*", "--include-directories"])
+        assert result.exit_code == 0
+        assert "test_dir/test_subdir/any_file.txt" in result.output
+        
         result = runner.invoke(cli, ["test_dir", "--ignore", ""])
 
 


### PR DESCRIPTION
Closes #7 closes #29 .

Changes the default behaviour of `--ignore` to also ignore directory names matching the pattern. I thought this would be the default behaviour, and apparently others did as well. You can revert to the original behaviour by adding the `--include-directories` flag. Thus for:

```
my_directory/
├── file1.txt
├── file2.txt
├── .hidden_file.txt
├── temp.log
└── subdirectory/
    └── file3.txt
```

`files-to-prompt my_directory --ignore "sub*"` will exclude `file3.txt`, `files-to-prompt my_directory --ignore "sub*" --include-directories` will not.