### PR TITLE
Preventing rewrapping

### DIFF
--- a/files_to_prompt/cli.py
+++ b/files_to_prompt/cli.py
@@ -157,10 +157,12 @@ def cli(
     Takes one or more paths to files or directories and outputs every file,
     recursively, each one preceded with its filename like this:
 
+    \b
     path/to/file.py
     ----
     Contents of file.py goes here
 
+    \b
     ---
     path/to/file2.py
     ---


### PR DESCRIPTION
Use \b to prevent rewrapping of paragraphs containing output example in help text.

See https://click.palletsprojects.com/en/stable/documentation/#preventing-rewrapping

Closes: #31
