### PR TITLE
Fix help output formatting and update XML example

### DIFF
--- a/files_to_prompt/cli.py
+++ b/files_to_prompt/cli.py
@@ -157,10 +157,12 @@ def cli(
     Takes one or more paths to files or directories and outputs every file,
     recursively, each one preceded with its filename like this:
 
+    \b
     path/to/file.py
     ----
     Contents of file.py goes here
 
+    \b
     ---
     path/to/file2.py
     ---
@@ -168,15 +170,20 @@ def cli(
 
     If the `--cxml` flag is provided, the output will be structured as follows:
 
+    \b
     <documents>
-    <document path="path/to/file1.txt">
+    <document index="1">
+    <source>my_directory/file1.txt</source>
+    <document_content>
     Contents of file1.txt
+    </document_content>
     </document>
-
-    <document path="path/to/file2.txt">
+    <document index="2">
+    <source>my_directory/file2.txt</source>
+    <document_content>
     Contents of file2.txt
+    </document_content>
     </document>
-    ...
     </documents>
     """
     # Reset global_index for pytest


### PR DESCRIPTION
The current help text has two issues:

- The format for the Claude XML is out of sync with the code. I copied the example from the README.md.
- Added `\b` to the example sections. Without it, click doesn't respect line breaks. With it, it keeps the line breaks as-is.

Output after changes:

```
Usage: files-to-prompt [OPTIONS] [PATHS]...

  Takes one or more paths to files or directories and outputs every file,
  recursively, each one preceded with its filename like this:

  path/to/file.py
  ----
  Contents of file.py goes here

  ---
  path/to/file2.py
  ---
  ...

  If the `--cxml` flag is provided, the output will be structured as follows:

  <documents>
  <document index="1">
  <source>my_directory/file1.txt</source>
  <document_content>
  Contents of file1.txt
  </document_content>
  </document>
  <document index="2">
  <source>my_directory/file2.txt</source>
  <document_content>
  Contents of file2.txt
  </document_content>
  </document>
  </documents>

Options:
  -e, --extension TEXT
  --include-hidden      Include files and folders starting with .
  --ignore-gitignore    Ignore .gitignore files and include all files
  --ignore TEXT         List of patterns to ignore
  -o, --output PATH     Output to a file instead of stdout
  -c, --cxml            Output in XML-ish format suitable for Claude's long
                        context window.
  --version             Show the version and exit.
  --help                Show this message and exit.
```