### PR TITLE
Fix short flag for Claude XML output in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This will output the contents of every file, with each file preceded by its rela
   files-to-prompt path/to/directory --ignore "*.log" --ignore "temp*"
   ```
 
-- `c/--cxml`: Output in Claude XML format.
+- `-c/--cxml`: Output in Claude XML format.
 
   ```bash
   files-to-prompt path/to/directory --cxml


### PR DESCRIPTION
I just saw your cool post on [o3-mini-documentation](https://simonwillison.net/2025/Feb/5/o3-mini-documentation/) and noticed the missing dash (-) on the short `--cxml` switch. 

Fun tool, and post, thanks!