### PR TITLE
Prevent duplicate file processing

### DIFF
--- a/files_to_prompt/cli.py
+++ b/files_to_prompt/cli.py
@@ -5,6 +5,7 @@ from fnmatch import fnmatch
 import click
 
 global_index = 1
+processed_paths = set()
 
 EXT_TO_LANG = {
     "py": "python",
@@ -155,6 +156,9 @@ def process_path(
 
             for file in sorted(files):
                 file_path = os.path.join(root, file)
+                if file_path in processed_paths:
+                    continue
+                processed_paths.add(file_path)
                 try:
                     with open(file_path, "r") as f:
                         print_path(
@@ -292,9 +296,10 @@ def cli(
         Contents of file1.py
         ```
     """
-    # Reset global_index for pytest
-    global global_index
+    # Reset globals for pytest
+    global global_index, processed_paths
     global_index = 1
+    processed_paths = set()
 
     # Read paths from stdin if available
     stdin_paths = read_paths_from_stdin(use_null_separator=null)

--- a/tests/test_files_to_prompt.py
+++ b/tests/test_files_to_prompt.py
@@ -439,3 +439,23 @@ def test_markdown(tmpdir, option):
             "`````\n"
         )
         assert expected.strip() == actual.strip()
+
+def test_duplicate_paths(tmpdir):
+    runner = CliRunner()
+    with tmpdir.as_cwd():
+        os.makedirs("test_dir/subdir")
+        with open("test_dir/file1.txt", "w") as f:
+            f.write("File 1 contents")
+        with open("test_dir/subdir/file2.txt", "w") as f:
+            f.write("File 2 contents in subdir")
+
+        # Invoke with both "test_dir" and "test_dir/subdir"
+        result = runner.invoke(cli, ["test_dir", "test_dir/subdir"])
+        assert result.exit_code == 0
+        assert "test_dir/file1.txt" in result.output
+        assert "File 1 contents" in result.output
+        assert "test_dir/subdir/file2.txt" in result.output
+        assert "File 2 contents in subdir" in result.output
+
+        # Ensure file2.txt is included only once
+        assert result.output.count("test_dir/subdir/file2.txt") == 1


### PR DESCRIPTION
This pull request adds a `processed_paths` set to handle cases where users may inadvertently specify duplicate file paths. It ensures that each file is processed only once, even if provided multiple times.

### Key Changes:
- **`processed_paths` Set:** Tracks file paths to avoid re-processing.
- **File Path Check:** Skips files already processed, ensuring no duplicates are handled.
- **Reset for Tests:** Clears `processed_paths` at the start of the `cli` function for proper test execution.

### Reasoning:
To prevent redundant file processing when users provide duplicate paths, improving efficiency and robustness.
