### PR TITLE
Produce empty output for empty paths list under -c

### DIFF
--- a/files_to_prompt/cli.py
+++ b/files_to_prompt/cli.py
@@ -328,7 +328,7 @@ def cli(
             markdown,
             line_numbers,
         )
-    if claude_xml:
+    if claude_xml and paths:
         writer("</documents>")
     if fp:
         fp.close()

--- a/tests/test_files_to_prompt.py
+++ b/tests/test_files_to_prompt.py
@@ -403,6 +403,18 @@ def test_paths_from_arguments_and_stdin(tmpdir):
         assert "test_dir2/file2.txt" in result.output
         assert "Contents of file2" in result.output
 
+def test_empty_path_set(tmpdir):
+    runner = CliRunner()
+    with tmpdir.as_cwd():
+        # Test empty path set
+        result = runner.invoke(
+            cli,
+            args=["-c"],
+            input="",
+        )
+        assert result.exit_code == 0
+        assert "" == result.output
+
 
 @pytest.mark.parametrize("option", ("-m", "--markdown"))
 def test_markdown(tmpdir, option):


### PR DESCRIPTION
The earlier version printed only the end tag </documents> when paths was an empty list. This version does so only if paths is non-empty. A new test verifies the behavior.