### PR TITLE
Add clipboard support and fix windows paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,22 @@ This will output the contents of every file, with each file preceded by its rela
   find . -name "*.py" -print0 | files-to-prompt --null
   ```
 
+- `-C/--copy`: Copy the output to the clipboard instead of printing to stdout. Useful for quickly getting file contents ready to paste into an LLM chat interface.
+
+  ```bash
+  files-to-prompt path/to/directory --copy
+  ```
+  
+  This option cannot be used together with `-o/--output`. If the clipboard operation fails, the output will be printed to stdout as a fallback.
+
+Using `-C/--copy` requires the optional `pyperclip` dependency:
+
+```bash
+uv pip install 'files-to-prompt[clipboard]'
+```
+
+On Linux you also need `xclip` or `xsel`, and on macOS the standard `pbcopy` utility must be available.
+
 ### Example
 
 Suppose you have a directory structure like this:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ dependencies = [
     "click"
 ]
 
+[project.optional-dependencies]
+clipboard = [
+    "pyperclip"
+]
+
 [project.urls]
 Homepage = "https://github.com/simonw/files-to-prompt"
 Changelog = "https://github.com/simonw/files-to-prompt/releases"
@@ -21,6 +26,3 @@ CI = "https://github.com/simonw/files-to-prompt/actions"
 
 [project.entry-points.console_scripts]
 files-to-prompt = "files_to_prompt.cli:cli"
-
-[project.optional-dependencies]
-test = ["pytest"]


### PR DESCRIPTION
- Introduced \-C/--copy\ option to copy output to clipboard using \pyperclip\.
- Updated \README.md\ to document the new clipboard feature and installation instructions for \pyperclip\.
- Added tests for clipboard functionality
- Fixed slashes so tests work between windows & linux

Closes #63