### PR TITLE
support `--since` flag to only include changed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,29 @@ This will output the contents of every file, with each file preceded by its rela
   find . -name "*.py" -print0 | files-to-prompt --null
   ```
 
+- `--since <REF>`: Only include files changed since a Git revision (commit SHA, tag, or branch).
+
+  * Default scope is **working**: commits after `REF` + staged + unstaged + untracked (Git ignores respected).
+  * Paths given on the command line (or via stdin) further restrict the set.
+  * In this mode, `--ignore-gitignore` is ignored.
+
+  ```bash
+  files-to-prompt --since HEAD
+  files-to-prompt --since v1.2.0 -e py
+  files-to-prompt --since main src tests
+  ```
+
+- `--since-scope <working|committed|staged>`: Control what "changed since REF" means (default: `working`).
+
+  * `working`: commits after `REF` + staged + unstaged + untracked
+  * `committed`: only commits after `REF` (no staged/unstaged/untracked)
+  * `staged`: only index vs `REF` (no unstaged/untracked)
+
+  ```bash
+  files-to-prompt --since v1.2.0 --since-scope committed
+  files-to-prompt --since HEAD --since-scope staged
+  ```
+
 ### Example
 
 Suppose you have a directory structure like this:
@@ -191,45 +214,7 @@ You can mix and match paths from command line arguments and stdin:
 find . -mtime -1 | files-to-prompt README.md
 ```
 
-### Selecting files changed since a Git revision
-
-Use `--since REF` to include only files that have changed since a given Git revision
-(commit SHA, tag, or branch).
-
-Other filters (`-e/--extension`, `--ignore`, `--ignore-files-only`, `--include-hidden`) still apply.
-Passing paths (args or stdin) further restricts the set.
-
-#### Controlling what "changed since REF" means
-
-`--since REF` accepts an optional scope with `--since-scope`:
-
-- **working** (default): commits after `REF` + staged changes + unstaged changes,
-  plus untracked files (Git ignores respected).
-- **committed**: only commits after `REF` (no staged/unstaged/untracked).
-- **staged**: only files staged in the index relative to `REF` (no unstaged/untracked).
-
-Examples:
-```bash
-# Default: everything in your working copy since REF
-files-to-prompt --since HEAD
-
-# Only what's been committed after REF
-files-to-prompt --since v1.2.0 --since-scope committed
-
-# Only what you've staged to commit (index vs REF)
-files-to-prompt --since HEAD --since-scope staged
-
-# Other examples with filters
-files-to-prompt --since abc123 -e py
-files-to-prompt --since main src tests
-```
-
-Notes:
-- Paths are repo-root-relative in `--since` mode.
-- Deleted files are not emitted.
-- Untracked files are included **only** with `--since-scope working`.
-- `--ignore-gitignore` is ignored with `--since` (a warning is printed); Git's ignore rules are always used for untracked detection.
-- `-e/--extension`, `--ignore`, `--ignore-files-only`, `--include-hidden`, and path arguments/stdin still apply after the changed set is computed.
+**Notes for `--since`**: paths are repo-root-relative; deleted files are not emitted. Untracked files are included only with `--since-scope working`. Other filters (`-e/--extension`, `--ignore`, `--ignore-files-only`, `--include-hidden`) still apply.
 
 ### Claude XML Output
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,30 @@ You can mix and match paths from command line arguments and stdin:
 find . -mtime -1 | files-to-prompt README.md
 ```
 
+### Selecting files changed since a Git revision
+
+Use `--since REF` to include only files that have changed since a given Git revision
+(commit SHA, tag, or branch).
+
+Includes:
+- Tracked changes between `REF` and your current working tree.
+- Untracked files (Git's ignore rules always apply).
+
+Notes:
+- Deleted files are not included.
+- Paths are repo-root-relative in this mode.
+- `--ignore-gitignore` is ignored (a warning is printed).
+
+Other filters (`-e/--extension`, `--ignore`, `--ignore-files-only`, `--include-hidden`) still apply.
+Passing paths (args or stdin) further restricts the set.
+
+Examples:
+```bash
+files-to-prompt --since HEAD
+files-to-prompt --since abc123 -e py
+files-to-prompt --since main src tests
+```
+
 ### Claude XML Output
 
 Anthropic has provided [specific guidelines](https://docs.anthropic.com/claude/docs/long-context-window-tips) for optimally structuring prompts to take advantage of Claude's extended context window.

--- a/README.md
+++ b/README.md
@@ -196,24 +196,40 @@ find . -mtime -1 | files-to-prompt README.md
 Use `--since REF` to include only files that have changed since a given Git revision
 (commit SHA, tag, or branch).
 
-Includes:
-- Tracked changes between `REF` and your current working tree.
-- Untracked files (Git's ignore rules always apply).
-
-Notes:
-- Deleted files are not included.
-- Paths are repo-root-relative in this mode.
-- `--ignore-gitignore` is ignored (a warning is printed).
-
 Other filters (`-e/--extension`, `--ignore`, `--ignore-files-only`, `--include-hidden`) still apply.
 Passing paths (args or stdin) further restricts the set.
 
+#### Controlling what "changed since REF" means
+
+`--since REF` accepts an optional scope with `--since-scope`:
+
+- **working** (default): commits after `REF` + staged changes + unstaged changes,
+  plus untracked files (Git ignores respected).
+- **committed**: only commits after `REF` (no staged/unstaged/untracked).
+- **staged**: only files staged in the index relative to `REF` (no unstaged/untracked).
+
 Examples:
 ```bash
+# Default: everything in your working copy since REF
 files-to-prompt --since HEAD
+
+# Only what's been committed after REF
+files-to-prompt --since v1.2.0 --since-scope committed
+
+# Only what you've staged to commit (index vs REF)
+files-to-prompt --since HEAD --since-scope staged
+
+# Other examples with filters
 files-to-prompt --since abc123 -e py
 files-to-prompt --since main src tests
 ```
+
+Notes:
+- Paths are repo-root-relative in `--since` mode.
+- Deleted files are not emitted.
+- Untracked files are included **only** with `--since-scope working`.
+- `--ignore-gitignore` is ignored with `--since` (a warning is printed); Git's ignore rules are always used for untracked detection.
+- `-e/--extension`, `--ignore`, `--ignore-files-only`, `--include-hidden`, and path arguments/stdin still apply after the changed set is computed.
 
 ### Claude XML Output
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "files-to-prompt"
 version = "0.6"
 description = "Concatenate a directory full of files into a single prompt for use with LLMs"
 readme = "README.md"
-authors = [{name = "Simon Willison"}]
+authors = [{name = "Simon Willison"}, {name = "Dan MacKinlay"}]
 license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 classifiers = [


### PR DESCRIPTION
Very useful for getting an LLM to code-review what you just did; this adds flags that allow us to, e.g., create a prompt from files that have changed since `HEAD^^`. Auxiliary flag `-since-scope` allows us to include staged/working files or not.