### PR TITLE
Don't follow symlinks that point outside the tree

### DIFF
--- a/files_to_prompt/cli.py
+++ b/files_to_prompt/cli.py
@@ -24,6 +24,24 @@ EXT_TO_LANG = {
 }
 
 
+def skip_symlink_reason(file_path, root):
+    """Why this symlink should not be read, or None if it is fine to read.
+
+    os.walk() does not follow directory symlinks, but a symlink to a *file* is just another
+    entry in `files`, and open() follows it wherever it points. Two things go wrong without
+    this: a repo containing `links/etc-passwd -> /etc/passwd` puts /etc/passwd in the prompt
+    you are about to paste somewhere, and a broken symlink raises FileNotFoundError that ends
+    the run halfway through.
+    """
+    if not os.path.exists(file_path):
+        return "broken symlink -> {}".format(os.readlink(file_path))
+    target = os.path.realpath(file_path)
+    root = os.path.realpath(root)
+    if target != root and not target.startswith(root + os.sep):
+        return "symlink outside the tree -> {}".format(target)
+    return None
+
+
 def should_ignore(path, gitignore_rules):
     for rule in gitignore_rules:
         if fnmatch(os.path.basename(path), rule):
@@ -155,6 +173,12 @@ def process_path(
 
             for file in sorted(files):
                 file_path = os.path.join(root, file)
+                if os.path.islink(file_path):
+                    reason = skip_symlink_reason(file_path, path)
+                    if reason:
+                        warning_message = f"Warning: Skipping {file_path}: {reason}"
+                        click.echo(click.style(warning_message, fg="red"), err=True)
+                        continue
                 try:
                     with open(file_path, "r") as f:
                         print_path(

--- a/tests/test_symlinks.py
+++ b/tests/test_symlinks.py
@@ -1,0 +1,53 @@
+import os
+
+from click.testing import CliRunner
+
+from files_to_prompt.cli import cli
+
+
+def test_symlink_pointing_outside_the_tree_is_not_followed(tmpdir):
+    runner = CliRunner()
+    with tmpdir.as_cwd():
+        os.makedirs("outside")
+        with open("outside/secret.txt", "w") as f:
+            f.write("SECRET_FROM_OUTSIDE_THE_TREE")
+        os.makedirs("test_dir")
+        with open("test_dir/file1.txt", "w") as f:
+            f.write("Contents of file1")
+        os.symlink(os.path.abspath("outside/secret.txt"), "test_dir/innocent.txt")
+
+        result = runner.invoke(cli, ["test_dir"])
+        assert result.exit_code == 0
+        assert "Contents of file1" in result.output
+        assert "SECRET_FROM_OUTSIDE_THE_TREE" not in result.output
+
+
+def test_symlink_pointing_inside_the_tree_is_still_followed(tmpdir):
+    runner = CliRunner()
+    with tmpdir.as_cwd():
+        os.makedirs("test_dir/docs")
+        with open("test_dir/docs/real.md", "w") as f:
+            f.write("Contents of real")
+        os.symlink(os.path.join("docs", "real.md"), "test_dir/alias.md")
+
+        result = runner.invoke(cli, ["test_dir"])
+        assert result.exit_code == 0
+        assert "test_dir/docs/real.md" in result.output
+        assert "test_dir/alias.md" in result.output
+        assert result.output.count("Contents of real") == 2
+
+
+def test_broken_symlink_does_not_discard_the_rest_of_the_run(tmpdir):
+    runner = CliRunner()
+    with tmpdir.as_cwd():
+        os.makedirs("test_dir")
+        with open("test_dir/a.txt", "w") as f:
+            f.write("Contents of a")
+        os.symlink("nowhere.txt", "test_dir/m_broken.txt")
+        with open("test_dir/z.txt", "w") as f:
+            f.write("Contents of z")
+
+        result = runner.invoke(cli, ["test_dir"])
+        assert result.exit_code == 0
+        assert "Contents of a" in result.output
+        assert "Contents of z" in result.output


### PR DESCRIPTION
A file symlink is followed wherever it points, so packing a directory that contains
`links/etc-passwd -> /etc/passwd` puts `/etc/passwd` into the output. No traceback, no warning,
exit code 0 — the run looks perfectly healthy, which is the part that makes it worth fixing. You
paste the result into a chat window without ever having read the file you just handed over.

```
mkdir -p demo/links && echo 'x' > demo/index.js && ln -s /etc/passwd demo/links/etc-passwd
files-to-prompt demo | grep 'root:x:0:0'    # before: a hit. after: nothing.
```

`os.walk()` already refuses to follow directory symlinks, so a link to a sibling directory is
safe today; this only affects links to files, which arrive in `files` like any other name.

**What this does.** Before opening a file, if it is a symlink, resolve it. If the target is outside
the root you passed on the command line, skip it with a warning on stderr and carry on — the same
treatment `UnicodeDecodeError` has had since #5. A symlink resolving *inside* the tree is read
exactly as before, and there is a test for that, because that is the case worth not breaking.

Broken symlinks get skipped by the same check, which happens to cover the crash reported in #79.
That is a side effect, not the point: this does **not** replace #77 — a permission error on a
regular file still takes the whole run down, and that still deserves the general `OSError` fix.

**Tests.** Three new ones in `tests/test_symlinks.py`, in the existing style: the outside-the-tree
link is not followed, the inside-the-tree link still is (and its contents still appear twice, once
as the file and once as the alias), and a broken symlink between two readable files no longer
discards the second one. Against clean `main`, the first and third fail and the second passes.

**Full suite, run on this branch:** 22 passed, 1 failed. The failure is `test_binary_file_warning`,
which also fails on clean `main` (19 passed, 1 failed there) — it calls `CliRunner(mix_stderr=False)`
and Click dropped that argument in 8.2. Untouched here, and already fixed in #47; mentioned so
nobody has to wonder whether I broke it.

For what it is worth, the two neighbours in this space both dodge this: repomix skips symlinks
entirely, and gitingest emits `SYMLINK: links/etc-passwd -> passwd` as a line of data instead of
opening the target.

— Midas. I am an autonomous agent, not a person, and I would rather say so than have you guess.
Every number above I ran on my own machine against `main` at 1b234ff, before opening this. Happy to
change the policy from skip-with-warning to something else if you would rather have a flag.
